### PR TITLE
Date truncation fix

### DIFF
--- a/scex-util/src/main/scala/com/avsystem/scex/util/EnrichedDate.scala
+++ b/scex-util/src/main/scala/com/avsystem/scex/util/EnrichedDate.scala
@@ -27,7 +27,7 @@ final class EnrichedDate(private val wrapped: Date) extends AnyVal {
   def truncateToSeconds: Date = DateUtils.truncate(wrapped, Calendar.SECOND)
   def truncateToMinutes: Date = DateUtils.truncate(wrapped, Calendar.MINUTE)
   def truncateToHours: Date = DateUtils.truncate(wrapped, Calendar.HOUR)
-  def truncateToDays: Date = DateUtils.truncate(wrapped, Calendar.DAY_OF_YEAR)
+  def truncateToDays: Date = DateUtils.truncate(wrapped, Calendar.DAY_OF_MONTH)
   def truncateToMonths: Date = DateUtils.truncate(wrapped, Calendar.MONTH)
   def truncateToYears: Date = DateUtils.truncate(wrapped, Calendar.YEAR)
 

--- a/scex-util/src/test/scala/com/avsystem/scex/util/EnrichedDateTest.scala
+++ b/scex-util/src/test/scala/com/avsystem/scex/util/EnrichedDateTest.scala
@@ -23,19 +23,19 @@ class EnrichedDateTest extends FunSuite {
   test("truncate to minutes")(assert(testDate.truncateToMinutes === new Date(1555505700000L)))
   // 2019-04-17 12:00:00.000 UTC
   test("truncate to hours")(assert(testDate.truncateToHours === new Date(1555502400000L)))
-  // 2019-04-17 00:00.00.000 default time zone
+  // 2019-04-17 00:00:00.000 default time zone
   val truncatedToDays: Calendar = localMidnight
   truncatedToDays.set(Calendar.YEAR, 2019)
   truncatedToDays.set(Calendar.MONTH, Calendar.APRIL)
   truncatedToDays.set(Calendar.DAY_OF_MONTH, 17)
   test("truncate to day")(assert(testDate.truncateToDays === truncatedToDays.getTime))
-  // 2019-04-01 00:00.00.000 default time zone
+  // 2019-04-01 00:00:00.000 default time zone
   val truncatedToMonths: Calendar = localMidnight
   truncatedToMonths.set(Calendar.YEAR, 2019)
   truncatedToMonths.set(Calendar.MONTH, Calendar.APRIL)
   truncatedToMonths.set(Calendar.DAY_OF_MONTH, 1)
   test("truncate to month")(assert(testDate.truncateToMonths === truncatedToMonths.getTime))
-  // 2019-01-01 00:00.00.000 default time zone
+  // 2019-01-01 00:00:00.000 default time zone
   val truncatedToYears: Calendar = localMidnight
   truncatedToYears.set(Calendar.YEAR, 2019)
   truncatedToYears.set(Calendar.MONTH, Calendar.JANUARY)

--- a/scex-util/src/test/scala/com/avsystem/scex/util/EnrichedDateTest.scala
+++ b/scex-util/src/test/scala/com/avsystem/scex/util/EnrichedDateTest.scala
@@ -1,0 +1,44 @@
+package com.avsystem.scex.util
+
+import java.util.{Calendar, Date}
+
+import org.scalatest.FunSuite
+
+class EnrichedDateTest extends FunSuite {
+  // 2019-04-17 12:55:14.456 UTC
+  val testDate: EnrichedDate = new EnrichedDate(new Date(1555505714456L))
+
+  def localMidnight: Calendar = {
+    val time = Calendar.getInstance()
+    time.set(Calendar.HOUR_OF_DAY, 0)
+    time.set(Calendar.MINUTE, 0)
+    time.set(Calendar.SECOND, 0)
+    time.set(Calendar.MILLISECOND, 0)
+    time
+  }
+
+  // 2019-04-17 12:55:14.000 UTC
+  test("truncate to seconds")(assert(testDate.truncateToSeconds === new Date(1555505714000L)))
+  // 2019-04-17 12:55:00.000 UTC
+  test("truncate to minutes")(assert(testDate.truncateToMinutes === new Date(1555505700000L)))
+  // 2019-04-17 12:00:00.000 UTC
+  test("truncate to hours")(assert(testDate.truncateToHours === new Date(1555502400000L)))
+  // 2019-04-17 00:00.00.000 default time zone
+  val truncatedToDays: Calendar = localMidnight
+  truncatedToDays.set(Calendar.YEAR, 2019)
+  truncatedToDays.set(Calendar.MONTH, Calendar.APRIL)
+  truncatedToDays.set(Calendar.DAY_OF_MONTH, 17)
+  test("truncate to day")(assert(testDate.truncateToDays === truncatedToDays.getTime))
+  // 2019-04-01 00:00.00.000 default time zone
+  val truncatedToMonths: Calendar = localMidnight
+  truncatedToMonths.set(Calendar.YEAR, 2019)
+  truncatedToMonths.set(Calendar.MONTH, Calendar.APRIL)
+  truncatedToMonths.set(Calendar.DAY_OF_MONTH, 1)
+  test("truncate to month")(assert(testDate.truncateToMonths === truncatedToMonths.getTime))
+  // 2019-01-01 00:00.00.000 default time zone
+  val truncatedToYears: Calendar = localMidnight
+  truncatedToYears.set(Calendar.YEAR, 2019)
+  truncatedToYears.set(Calendar.MONTH, Calendar.JANUARY)
+  truncatedToYears.set(Calendar.DAY_OF_MONTH, 1)
+  test("truncate to year")(assert(testDate.truncateToYears === truncatedToYears.getTime))
+}


### PR DESCRIPTION
Changes:
 - `Calendar.DAY_OF_YEAR` argument (causing `IllegalArgumentException`) switched to `Calendar.DAY_OF_MONTH` in `EnrichedDate#truncateToDays` implementation,
 - Tests for truncation methods in `EnrichedDate` implemented.