### PR TITLE
Draft: Added a test for invalid literal breaking the compiler

### DIFF
--- a/scex-core/src/test/scala/com/avsystem/scex/compiler/InvalidLiteralTest.scala
+++ b/scex-core/src/test/scala/com/avsystem/scex/compiler/InvalidLiteralTest.scala
@@ -1,0 +1,22 @@
+package com.avsystem.scex.compiler
+
+import com.avsystem.scex.compiler.ScexCompiler.CompilationFailedException
+import com.avsystem.scex.japi.{DefaultJavaScexCompiler, JavaScexCompiler}
+import org.scalatest.funsuite.AnyFunSuite
+
+class InvalidLiteralTest extends AnyFunSuite with CompilationTest {
+  override protected def createCompiler: JavaScexCompiler = {
+    val settings = new ScexSettings
+    settings.classfileDirectory.value = "testClassfileCache"
+    //evaluating getter adapters fixes the problem (since the invalid expression isn't the first thing compiled)
+    settings.noGetterAdapters.value = true
+    new DefaultJavaScexCompiler(settings)
+  }
+
+  test("Invalid literal should not break the scex compiler") {
+    intercept[CompilationFailedException] {
+      evaluate[String]("11compilation_fail11")
+    }
+    assert("ok" == evaluate[String]("\"ok\""))
+  }
+}


### PR DESCRIPTION
Whenever a non-compilable expression is the first thing evaluated after the Scala Compiler is created, all further expressions fail with a `scala.reflect.internal.FatalError: package scala does not have a member Nil`