### PR TITLE
Fixed infinite background compilation in scala 2.13.14

### DIFF
--- a/scex-core/src/main/scala/com/avsystem/scex/compiler/ScexSourceFile.scala
+++ b/scex-core/src/main/scala/com/avsystem/scex/compiler/ScexSourceFile.scala
@@ -7,4 +7,13 @@ import scala.reflect.internal.util.BatchSourceFile
  * Author: ghik
  */
 class ScexSourceFile(name: String, contents: String, val shared: Boolean)
-  extends BatchSourceFile(name, contents)
+  extends BatchSourceFile(name, contents) {
+
+  override def equals(that: Any): Boolean = that match {
+    case that: ScexSourceFile => file.path == that.file.path && start == that.start
+    case _ => super.equals(that)
+  }
+
+  override def hashCode: Int = file.path.## + start.##
+
+}

--- a/scex-core/src/test/scala/com/avsystem/scex/compiler/OufOfDateUnitScexCompilerTest.scala
+++ b/scex-core/src/test/scala/com/avsystem/scex/compiler/OufOfDateUnitScexCompilerTest.scala
@@ -1,0 +1,45 @@
+package com.avsystem.scex.compiler
+
+import com.avsystem.scex.compiler.presentation.ScexPresentationCompiler
+import com.avsystem.scex.japi.{JavaScexCompiler, ScalaTypeTokens}
+import com.avsystem.scex.util.{PredefinedAccessSpecs, SimpleContext}
+import org.scalatest.funsuite.AnyFunSuite
+
+class OufOfDateUnitScexCompilerTest extends AnyFunSuite with CompilationTest {
+
+  override protected def createCompiler: noCacheCompiler.type = noCacheCompiler
+
+  object noCacheCompiler
+    extends ScexCompiler
+      with ScexPresentationCompiler
+      with JavaScexCompiler
+      with ClassfileReusingScexCompiler {
+
+    val settings = new ScexSettings
+    settings.classfileDirectory.value = "testClassfileCache"
+  }
+
+  /** *
+   * Purpose of this test it to compile same expression using same profile multiple times with disabled caching to force execution of backgroundCompile method
+   * backgroundCompile was infinitely executed with changes introduced by 2.13.13
+   */
+  test("out of date compilation") {
+    val acl = PredefinedAccessSpecs.basicOperations
+    val profile = createProfile(acl)
+
+    def compileExpression(): Unit = {
+      compiler.buildExpression
+        .contextType(ScalaTypeTokens.create[SimpleContext[Unit]])
+        .resultType(classOf[String])
+        .expression(s""""value"""")
+        .template(false)
+        .profile(profile)
+        .get
+    }
+
+    compileExpression()
+    compileExpression()
+  }
+
+
+}


### PR DESCRIPTION
Fixed infinite background compilation caused by changes in scala.reflect.internal.util.BatchSourceFile.hashCode introduced in scala 2.13.13
If scala.tools.nsc.interactive.Global#isOutOfDate returns true then scala.tools.nsc.interactive.Global#backgroundCompile runs infinitely because waitLoadedTypeResponses are not cleaned properly due to the fact that hashCode implementation for ScexSourceFile is taken from Object.
Changed hashCode/equals for ScexSourceFile so it's computed as before 2.13.13