### PR TITLE
 Disable unexpected compilation exceptions caching

### DIFF
--- a/scex-core/src/main/scala/com/avsystem/scex/compiler/ScexSettings.scala
+++ b/scex-core/src/main/scala/com/avsystem/scex/compiler/ScexSettings.scala
@@ -54,8 +54,8 @@ class ScexSettings extends Settings {
   final val backwardsCompatCacheVersion = StringSetting("-SCEXbackwards-compat-cache-version", "versionString",
     "Additional version string for controlling invalidation of classfile cache", "0")
 
-  final val cacheCompilationNPE = BooleanSetting("-SCEXcache-compilation-null-pointer",
-    "Disables caching of NullPointerExceptions that are thrown during the expression compilation", default = true)
+  final val cacheUnexpectedCompilationExceptions = BooleanSetting("-SCEXcache-unexpected-compilation-exceptions",
+    "Disables the caching of unexpected exceptions thrown during the expression compilation", default = true)
 
   def resolvedClassfileDir: Option[PlainDirectory] = Option(classfileDirectory.value)
     .filter(_.trim.nonEmpty).map(path => new PlainDirectory(new Directory(new File(path))))

--- a/scex-core/src/main/scala/com/avsystem/scex/compiler/ScexSettings.scala
+++ b/scex-core/src/main/scala/com/avsystem/scex/compiler/ScexSettings.scala
@@ -55,7 +55,8 @@ class ScexSettings extends Settings {
     "Additional version string for controlling invalidation of classfile cache", "0")
 
   final val cacheUnexpectedCompilationExceptions = BooleanSetting("-SCEXcache-unexpected-compilation-exceptions",
-    "Disables the caching of unexpected exceptions thrown during the expression compilation", default = true)
+    "Enables the caching of unexpected exceptions (such as NPE when accessing scex_classes) thrown during the expression compilation. " +
+      "Doesn't apply to CompilationFailedExceptions caused by e.g. syntax errors - they are always cached.", default = true)
 
   def resolvedClassfileDir: Option[PlainDirectory] = Option(classfileDirectory.value)
     .filter(_.trim.nonEmpty).map(path => new PlainDirectory(new Directory(new File(path))))

--- a/scex-core/src/main/scala/com/avsystem/scex/compiler/ScexSettings.scala
+++ b/scex-core/src/main/scala/com/avsystem/scex/compiler/ScexSettings.scala
@@ -56,7 +56,7 @@ class ScexSettings extends Settings {
 
   final val cacheUnexpectedCompilationExceptions = BooleanSetting("-SCEXcache-unexpected-compilation-exceptions",
     "Enables the caching of unexpected exceptions (such as NPE when accessing scex_classes) thrown during the expression compilation. " +
-      "Doesn't apply to CompilationFailedExceptions caused by e.g. syntax errors - they are always cached.", default = false)
+      "CompilationFailedExceptions are always cached, regardless of this setting. They indicate e.g. syntax errors, which should always be cached to avoid redundant compilations.", default = false)
 
   def resolvedClassfileDir: Option[PlainDirectory] = Option(classfileDirectory.value)
     .filter(_.trim.nonEmpty).map(path => new PlainDirectory(new Directory(new File(path))))

--- a/scex-core/src/main/scala/com/avsystem/scex/compiler/ScexSettings.scala
+++ b/scex-core/src/main/scala/com/avsystem/scex/compiler/ScexSettings.scala
@@ -54,6 +54,9 @@ class ScexSettings extends Settings {
   final val backwardsCompatCacheVersion = StringSetting("-SCEXbackwards-compat-cache-version", "versionString",
     "Additional version string for controlling invalidation of classfile cache", "0")
 
+  final val cacheCompilationNPE = BooleanSetting("-SCEXcache-compilation-null-pointer",
+    "Disables caching of NullPointerExceptions that are thrown during the expression compilation", default = true)
+
   def resolvedClassfileDir: Option[PlainDirectory] = Option(classfileDirectory.value)
     .filter(_.trim.nonEmpty).map(path => new PlainDirectory(new Directory(new File(path))))
 }

--- a/scex-core/src/main/scala/com/avsystem/scex/compiler/ScexSettings.scala
+++ b/scex-core/src/main/scala/com/avsystem/scex/compiler/ScexSettings.scala
@@ -56,7 +56,7 @@ class ScexSettings extends Settings {
 
   final val cacheUnexpectedCompilationExceptions = BooleanSetting("-SCEXcache-unexpected-compilation-exceptions",
     "Enables the caching of unexpected exceptions (such as NPE when accessing scex_classes) thrown during the expression compilation. " +
-      "Doesn't apply to CompilationFailedExceptions caused by e.g. syntax errors - they are always cached.", default = true)
+      "Doesn't apply to CompilationFailedExceptions caused by e.g. syntax errors - they are always cached.", default = false)
 
   def resolvedClassfileDir: Option[PlainDirectory] = Option(classfileDirectory.value)
     .filter(_.trim.nonEmpty).map(path => new PlainDirectory(new Directory(new File(path))))

--- a/scex-core/src/test/scala/com/avsystem/scex/compiler/ScexCompilationCachingTest.scala
+++ b/scex-core/src/test/scala/com/avsystem/scex/compiler/ScexCompilationCachingTest.scala
@@ -1,0 +1,109 @@
+package com.avsystem.scex.compiler
+
+import com.avsystem.scex.ExpressionProfile
+import com.avsystem.scex.compiler.ScexCompiler.CompileError
+import com.avsystem.scex.japi.{DefaultJavaScexCompiler, JavaScexCompiler, ScalaTypeTokens}
+import com.avsystem.scex.util.{PredefinedAccessSpecs, SimpleContext}
+import com.google.common.util.concurrent.UncheckedExecutionException
+import org.scalatest.funsuite.AnyFunSuite
+
+final class ScexCompilationCachingTest extends AnyFunSuite with CompilationTest {
+
+  private var compilationCount = 0
+
+  private val settings = new ScexSettings
+  settings.classfileDirectory.value = "testClassfileCache"
+  settings.noGetterAdapters.value = true // to reduce number of compilations in tests
+
+  private val acl = PredefinedAccessSpecs.basicOperations
+  private val defaultProfile = createProfile(acl, utils = "val utilValue = 42")
+
+  private def createFailingCompiler: JavaScexCompiler =
+    new DefaultJavaScexCompiler(settings) {
+      override protected def compile(sourceFile: ScexSourceFile): Either[ScexClassLoader, List[CompileError]] = {
+        compilationCount += 1
+        if (compilationCount == 1) throw new NullPointerException()
+        else super.compile(sourceFile)
+      }
+    }
+
+  private def createCountingCompiler: JavaScexCompiler =
+    new DefaultJavaScexCompiler(settings) {
+      override protected def compile(sourceFile: ScexSourceFile): Either[ScexClassLoader, List[CompileError]] = {
+        compilationCount += 1
+        super.compile(sourceFile)
+      }
+    }
+
+  override def newProfileName(): String = "constant_name"
+
+  private def compileExpression(
+    compiler: JavaScexCompiler,
+    expression: String = s""""value"""",
+    profile: ExpressionProfile = defaultProfile,
+  ): Unit = {
+    compiler.buildExpression
+      .contextType(ScalaTypeTokens.create[SimpleContext[Unit]])
+      .resultType(classOf[String])
+      .expression(expression)
+      .template(false)
+      .profile(profile)
+      .get
+  }
+
+  test("Unexpected exceptions should be cached by default") {
+    compilationCount = 0
+    val compiler = createFailingCompiler
+
+    assertThrows[UncheckedExecutionException](compileExpression(compiler))
+    assert(compilationCount == 1)
+    assertThrows[UncheckedExecutionException](compileExpression(compiler))
+    assert(compilationCount == 1) // result fetched from cache
+  }
+
+  test("Unexpected exceptions shouldn't be cached when disabled using ScexSettings") {
+    compilationCount = 0
+    val compiler = createFailingCompiler
+    compiler.settings.cacheUnexpectedCompilationExceptions.value = false
+
+    assertThrows[UncheckedExecutionException](compileExpression(compiler))
+    assert(compilationCount == 1) // utils compilation ended with NPE
+    compileExpression(compiler)
+    assert(compilationCount == 3) // 2x utils compilation + 1x final expression compilation
+  }
+
+  test("CompilationFailedExceptions should always be cached") {
+    compilationCount = 0
+    val compiler = createCountingCompiler
+    val profile = createProfile(acl, utils = """invalidValue""")
+
+    compiler.settings.cacheUnexpectedCompilationExceptions.value = true
+    assertThrows[UncheckedExecutionException](compileExpression(compiler, profile = profile))
+    assert(compilationCount == 1)
+    assertThrows[UncheckedExecutionException](compileExpression(compiler, profile = profile))
+    assert(compilationCount == 1)
+
+    compiler.settings.cacheUnexpectedCompilationExceptions.value = false
+    assertThrows[UncheckedExecutionException](compileExpression(compiler, profile = profile))
+    assert(compilationCount == 1)
+    assertThrows[UncheckedExecutionException](compileExpression(compiler, profile = profile))
+    assert(compilationCount == 1)
+  }
+
+  test("Successful compilation should always be cached") {
+    compilationCount = 0
+    val compiler = createCountingCompiler
+
+    compiler.settings.cacheUnexpectedCompilationExceptions.value = true
+    compileExpression(compiler)
+    assert(compilationCount == 2) // utils + expression value
+    compileExpression(compiler)
+    assert(compilationCount == 2)
+
+    compiler.settings.cacheUnexpectedCompilationExceptions.value = false
+    compileExpression(compiler)
+    assert(compilationCount == 2)
+    compileExpression(compiler)
+    assert(compilationCount == 2)
+  }
+}

--- a/scex-core/src/test/scala/com/avsystem/scex/compiler/ScexCompilationCachingTest.scala
+++ b/scex-core/src/test/scala/com/avsystem/scex/compiler/ScexCompilationCachingTest.scala
@@ -51,25 +51,25 @@ final class ScexCompilationCachingTest extends AnyFunSuite with CompilationTest 
       .get
   }
 
-  test("Unexpected exceptions should be cached by default") {
+  test("Unexpected exceptions shouldn't be cached by default") {
     compilationCount = 0
     val compiler = createFailingCompiler
-
-    assertThrows[UncheckedExecutionException](compileExpression(compiler))
-    assert(compilationCount == 1)
-    assertThrows[UncheckedExecutionException](compileExpression(compiler))
-    assert(compilationCount == 1) // result fetched from cache
-  }
-
-  test("Unexpected exceptions shouldn't be cached when disabled using ScexSettings") {
-    compilationCount = 0
-    val compiler = createFailingCompiler
-    compiler.settings.cacheUnexpectedCompilationExceptions.value = false
 
     assertThrows[UncheckedExecutionException](compileExpression(compiler))
     assert(compilationCount == 1) // utils compilation ended with NPE
     compileExpression(compiler)
     assert(compilationCount == 3) // 2x utils compilation + 1x final expression compilation
+  }
+
+  test("Unexpected exceptions should be cached when enabled using ScexSetting") {
+    compilationCount = 0
+    val compiler = createFailingCompiler
+    compiler.settings.cacheUnexpectedCompilationExceptions.value = true
+
+    assertThrows[UncheckedExecutionException](compileExpression(compiler))
+    assert(compilationCount == 1)
+    assertThrows[UncheckedExecutionException](compileExpression(compiler))
+    assert(compilationCount == 1) // result fetched from cache
   }
 
   test("CompilationFailedExceptions should always be cached") {


### PR DESCRIPTION
Since expression compilation can sometimes throw an unexpected `java.lang.NullPointerException: Cannot read the array length because "a" is null` due to I/O errors, it would be helpful to have the option to disable such error caching. Otherwise, the cached error is returned every time, paralyzing normal scex usage.