### PR TITLE
fix: Introduce escaping some special chars in SCEX typed vars

### DIFF
--- a/scex-core/src/test/scala/com/avsystem/scex/compiler/JavaScexCompilerTest.scala
+++ b/scex-core/src/test/scala/com/avsystem/scex/compiler/JavaScexCompilerTest.scala
@@ -65,27 +65,24 @@ class JavaScexCompilerTest extends AnyFunSuite with CompilationTest {
     }
   }
 
-  private def initContextWithTypedVariable(
-                                            variableName: String,
-                                            value: Double
-                                          ): SimpleContext[Unit] = {
+  private def initContextWithTypedVariable(variableName: String, value: Double): SimpleContext[Unit] = {
     val ctx = SimpleContext(())
     ctx.setTypedVariable(variableName, value)
     ctx
   }
 
   private def compileExpression(
-                                 expr: String,
-                                 variableName: String,
-                                 acl: List[MemberAccessSpec] = PredefinedAccessSpecs.basicOperations
-                               ): Expression[SimpleContext[Unit], Double] =
+    expr: String,
+    variableName: String,
+    accessControlList: List[MemberAccessSpec] = PredefinedAccessSpecs.basicOperations
+  ): Expression[SimpleContext[Unit], Double] =
     compiler.buildExpression
       .contextType(ScalaTypeTokens.create[SimpleContext[Unit]])
       .resultType(classOf[Double])
       .expression(expr)
       .template(false)
       .variableClass(variableName, classOf[Double])
-      .profile(createProfile(acl))
+      .profile(createProfile(accessControlList))
       .get
 }
 

--- a/scex-core/src/test/scala/com/avsystem/scex/compiler/JavaScexCompilerTest.scala
+++ b/scex-core/src/test/scala/com/avsystem/scex/compiler/JavaScexCompilerTest.scala
@@ -1,22 +1,29 @@
 package com.avsystem.scex.compiler
 
+import com.avsystem.scex.compiler.CodeGeneration.{TypedVariables, escapedChar}
+import com.avsystem.scex.compiler.JavaScexCompilerTest.SuspiciousCharsAllowedInVariableNames
+import com.avsystem.scex.compiler.ScexCompiler.CompilationFailedException
 import com.avsystem.scex.japi.{ScalaTypeTokens, XmlFriendlyJavaScexCompiler}
 import com.avsystem.scex.util.{PredefinedAccessSpecs, SimpleContext}
 import org.scalatest.funsuite.AnyFunSuite
 
 /**
-  * Author: ghik
-  * Created: 26/10/15.
-  */
+ * Author: ghik
+ * Created: 26/10/15.
+ */
 class JavaScexCompilerTest extends AnyFunSuite with CompilationTest {
   override protected def createCompiler = new XmlFriendlyJavaScexCompiler(new ScexSettings)
 
   test("typed variables test") {
+    // given a context with a valid typed variable
     val acl = PredefinedAccessSpecs.basicOperations
-    val expr = "#someDouble.toDegrees"
     val context = SimpleContext(())
     context.setTypedVariable("someDouble", math.Pi)
 
+    // given expression that uses the typed variable
+    val expr = "#someDouble.toDegrees"
+
+    // then expression is compiled without errors
     val cexpr = compiler.buildExpression
       .contextType(ScalaTypeTokens.create[SimpleContext[Unit]])
       .resultType(classOf[Double])
@@ -26,6 +33,72 @@ class JavaScexCompilerTest extends AnyFunSuite with CompilationTest {
       .profile(createProfile(acl))
       .get
 
-    assert(180.0 == cexpr(context))
+    // when expression is evaluated
+    val result = cexpr(context)
+
+    // then the result is correct
+    assert(math.Pi.toDegrees == result)
   }
+
+  TypedVariables.IllegalCharsInVarName.foreach { char =>
+    test(s"typed variables fail if char [code=${char.toInt}, escaped=${escapedChar(char)}] is in var name test") {
+      // given a context with a typed variable with illegal char in name
+      val acl = PredefinedAccessSpecs.basicOperations
+      val variableName = s"JP2NadajePoRazPierwszy$char"
+      val context = SimpleContext(())
+      context.setTypedVariable(variableName, math.Pi)
+
+      // given expression that uses the typed variable
+      val expr = s"#`$variableName`.toDegrees"
+
+      // then compilation should fail
+      withClue(s"[code=${char.toInt}] character in variable name [$variableName] should not be allowed") {
+        assertThrows[CompilationFailedException] {
+          compiler.buildExpression
+            .contextType(ScalaTypeTokens.create[SimpleContext[Unit]])
+            .resultType(classOf[Double])
+            .expression(expr)
+            .template(false)
+            .variableClass(variableName, classOf[Double])
+            .profile(createProfile(acl))
+            .get
+        }
+      }
+    }
+  }
+
+  SuspiciousCharsAllowedInVariableNames.foreach { char =>
+    test(s"typed variables work if char [code=$char.toInt] is in var name test") {
+      // given a context with a typed variable with non-standard characters in name
+      val acl = PredefinedAccessSpecs.basicOperations
+      val variableName = s"""2JPZnowuNadaje$char"""
+      val context = SimpleContext(())
+      context.setTypedVariable(variableName, math.Pi)
+
+      // given expression that uses the typed variable
+      val expr = s"#`$variableName`.toDegrees"
+
+      // then expression is compiled without errors
+      val cexpr = compiler.buildExpression
+        .contextType(ScalaTypeTokens.create[SimpleContext[Unit]])
+        .resultType(classOf[Double])
+        .expression(expr)
+        .template(false)
+        .variableClass(variableName, classOf[Double])
+        .profile(createProfile(acl))
+        .get
+
+      // when expression is evaluated
+      val result = cexpr(context)
+
+      // then the result is correct
+      assert(math.Pi.toDegrees == result)
+    }
+  }
+
+}
+
+object JavaScexCompilerTest {
+  // These characters caused compilation errors if they were put in variable names until v1.35 release
+  private val SuspiciousCharsAllowedInVariableNames: Seq[Char] = Seq(' ', '\t', '@', '/')
 }

--- a/scex-core/src/test/scala/com/avsystem/scex/compiler/JavaScexCompilerTest.scala
+++ b/scex-core/src/test/scala/com/avsystem/scex/compiler/JavaScexCompilerTest.scala
@@ -1,10 +1,12 @@
 package com.avsystem.scex.compiler
 
+import com.avsystem.scex.Expression
 import com.avsystem.scex.compiler.CodeGeneration.{TypedVariables, escapedChar}
 import com.avsystem.scex.compiler.JavaScexCompilerTest.SuspiciousCharsAllowedInVariableNames
 import com.avsystem.scex.compiler.ScexCompiler.CompilationFailedException
 import com.avsystem.scex.japi.{ScalaTypeTokens, XmlFriendlyJavaScexCompiler}
 import com.avsystem.scex.util.{PredefinedAccessSpecs, SimpleContext}
+import com.avsystem.scex.validation.SymbolValidator.MemberAccessSpec
 import org.scalatest.funsuite.AnyFunSuite
 
 /**
@@ -15,26 +17,16 @@ class JavaScexCompilerTest extends AnyFunSuite with CompilationTest {
   override protected def createCompiler = new XmlFriendlyJavaScexCompiler(new ScexSettings)
 
   test("typed variables test") {
-    // given a context with a valid typed variable
-    val acl = PredefinedAccessSpecs.basicOperations
-    val context = SimpleContext(())
-    context.setTypedVariable("someDouble", math.Pi)
-
-    // given expression that uses the typed variable
-    val expr = "#someDouble.toDegrees"
+    // given a valid type variable & an expression that uses the typed variable
+    val variableName = "someDouble"
+    val expr = s"#$variableName.toDegrees"
 
     // then expression is compiled without errors
-    val cexpr = compiler.buildExpression
-      .contextType(ScalaTypeTokens.create[SimpleContext[Unit]])
-      .resultType(classOf[Double])
-      .expression(expr)
-      .template(false)
-      .variableClass("someDouble", classOf[Double])
-      .profile(createProfile(acl))
-      .get
+    val compiledExpr = compileExpression(expr, variableName)
 
-    // when expression is evaluated
-    val result = cexpr(context)
+    // when expression is evaluated with valid value in context
+    val context = initContextWithTypedVariable(variableName, math.Pi)
+    val result = compiledExpr(context)
 
     // then the result is correct
     assert(math.Pi.toDegrees == result)
@@ -42,26 +34,14 @@ class JavaScexCompilerTest extends AnyFunSuite with CompilationTest {
 
   TypedVariables.IllegalCharsInVarName.foreach { char =>
     test(s"typed variables fail if char [code=${char.toInt}, escaped=${escapedChar(char)}] is in var name test") {
-      // given a context with a typed variable with illegal char in name
-      val acl = PredefinedAccessSpecs.basicOperations
-      val variableName = s"JP2NadajePoRazPierwszy$char"
-      val context = SimpleContext(())
-      context.setTypedVariable(variableName, math.Pi)
-
-      // given expression that uses the typed variable
+      // given a typed variable with illegal char in name & an expression that uses the typed variable
+      val variableName = s"2varName$char"
       val expr = s"#`$variableName`.toDegrees"
 
       // then compilation should fail
       withClue(s"[code=${char.toInt}] character in variable name [$variableName] should not be allowed") {
         assertThrows[CompilationFailedException] {
-          compiler.buildExpression
-            .contextType(ScalaTypeTokens.create[SimpleContext[Unit]])
-            .resultType(classOf[Double])
-            .expression(expr)
-            .template(false)
-            .variableClass(variableName, classOf[Double])
-            .profile(createProfile(acl))
-            .get
+          compileExpression(expr, variableName)
         }
       }
     }
@@ -69,36 +49,47 @@ class JavaScexCompilerTest extends AnyFunSuite with CompilationTest {
 
   SuspiciousCharsAllowedInVariableNames.foreach { char =>
     test(s"typed variables work if char [code=$char.toInt] is in var name test") {
-      // given a context with a typed variable with non-standard characters in name
-      val acl = PredefinedAccessSpecs.basicOperations
-      val variableName = s"""2JPZnowuNadaje$char"""
-      val context = SimpleContext(())
-      context.setTypedVariable(variableName, math.Pi)
-
-      // given expression that uses the typed variable
+      // given a typed variable with valid name & an expression that uses the typed variable
+      val variableName = s"""2varName$char"""
       val expr = s"#`$variableName`.toDegrees"
 
       // then expression is compiled without errors
-      val cexpr = compiler.buildExpression
-        .contextType(ScalaTypeTokens.create[SimpleContext[Unit]])
-        .resultType(classOf[Double])
-        .expression(expr)
-        .template(false)
-        .variableClass(variableName, classOf[Double])
-        .profile(createProfile(acl))
-        .get
+      val compiledExpr = compileExpression(expr, variableName)
 
-      // when expression is evaluated
-      val result = cexpr(context)
+      // when expression is evaluated with valid value in context
+      val context = initContextWithTypedVariable(variableName, math.Pi)
+      val result = compiledExpr(context)
 
       // then the result is correct
       assert(math.Pi.toDegrees == result)
     }
   }
 
+  private def initContextWithTypedVariable(
+                                            variableName: String,
+                                            value: Double
+                                          ): SimpleContext[Unit] = {
+    val ctx = SimpleContext(())
+    ctx.setTypedVariable(variableName, value)
+    ctx
+  }
+
+  private def compileExpression(
+                                 expr: String,
+                                 variableName: String,
+                                 acl: List[MemberAccessSpec] = PredefinedAccessSpecs.basicOperations
+                               ): Expression[SimpleContext[Unit], Double] =
+    compiler.buildExpression
+      .contextType(ScalaTypeTokens.create[SimpleContext[Unit]])
+      .resultType(classOf[Double])
+      .expression(expr)
+      .template(false)
+      .variableClass(variableName, classOf[Double])
+      .profile(createProfile(acl))
+      .get
 }
 
 object JavaScexCompilerTest {
-  // These characters caused compilation errors if they were put in variable names until v1.35 release
+  // These characters caused compilation errors if they were put in typed variable names until v1.35 release
   private val SuspiciousCharsAllowedInVariableNames: Seq[Char] = Seq(' ', '\t', '@', '/')
 }


### PR DESCRIPTION
Previously, commonly used chars like ` `, `@`, `"`, would cause SCEX compilation errors if used in typed var names. These errors happened due to inconsistency in how typed variables and their types are defined in `CodeGeneration` macros.

There are still some special chars like `\n` or `` ` `` that will break the macros generating the code for typed vars, but they might be less of a problem if they are publicly announced via `TypedVariables.IllegalCharsInVarName`. Without such public declaration the responsibility for validating the names is shifted towards the end application, while it isn't the one to impose the restrictions and throw compilation error.